### PR TITLE
Typo and grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ExpandableLayout
 
 ![ExpandableLayout](https://github.com/traex/ExpandableLayout/blob/master/header.png)
 
-ExpandableLayout provides an easy way to create a view called header with an expandable view. Both view are external layout to allow a maximum of customization. [You can find a sample](https://github.com/traex/ExpandableLayout/blob/master/sample/) that how to use an ExpandableLayout to your layout.
+ExpandableLayout provides an easy way to create a view called header with an expandable view. Both views have an external layout to allow maximum customization. [You can find a sample](https://github.com/traex/ExpandableLayout/blob/master/sample/) that how to use an ExpandableLayout to your layout.
 
 ![ExpandableLayout GIF](https://github.com/traex/ExpandableLayout/blob/master/demo.gif)
  
@@ -22,7 +22,7 @@ dependencies {
 
 #### ExpandableLayout
 
-Declare an ExpandableLayout inside your XML layout file. You also need to other layouts for header and content:
+Declare an ExpandableLayout inside your XML layout file. You also need other layouts for header and content:
 
 ``` xml
 


### PR DESCRIPTION
In the first paragraph, below the first picture diagram, the line is written as, " Both view are external layout to allow a maximum of customization." This line has some errors. 
The correct line could be, " Both views **have an** external layout to allow maximum customization. 

In the usage section, in the ExpandableLayout subheading, the line is written as, "You also need to other layouts for header and content:"
The corrected line could be written as, " You also need other layouts for header and content:"

Thank you.